### PR TITLE
Bump redox_users; Disable redox_users default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ maintenance = { status = "as-is" }
 libc = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_users = "0.3.0"
+redox_users = { version = "0.3.5", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }


### PR DESCRIPTION
I just released a new version of redox_users with argon behind a feature flag (enabled by default). There had been some buzz a while back about the size of the dependency tree for this crate and `dirs` earlier, so I've finally gotten around to doing my bit.