### PR TITLE
Fix memory leak in known_folder()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
             combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
             Some(PathBuf::from(ostr))
         } else {
+            combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
             None
         }
     }


### PR DESCRIPTION
The documentation for SHGetKnownFolderPath states:

> The calling process is responsible for freeing this resource once it
> is no longer needed by calling CoTaskMemFree, whether
> SHGetKnownFolderPath succeeds or not.

Currently the known_folder() function only calls CoTaskMemFree when
SHGetKnownFolderPath returns S_OK, causing a memory leak whenever
SHGetKnownFolderPath fails.

References:

https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath