### PR TITLE
Use redox_users::AllUsers::basic for clarity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ use super::redox_users::{All, AllUsers, Config};
 
 pub fn home_dir() -> Option<PathBuf> {
     let current_uid = redox_users::get_uid().ok()?;
-    let users = AllUsers::<()>::new(Config::default()).ok()?;
+    let users = AllUsers::basic(Config::default()).ok()?;
     let user = users.get_by_id(current_uid)?;
 
     Some(PathBuf::from(user.home.clone()))


### PR DESCRIPTION
This probably makes things more readable than the change in #11. Functionally they are the same.