### PR TITLE
Fix broken os.rs reference url in `home_dir`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::ptr;
 
 use super::libc;
 
-// https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/os.rs#L498
+// https://github.com/rust-lang/rust/blob/2682b88c526d493edeb2d3f2df358f44db69b73f/library/std/src/sys/unix/os.rs#L595
 pub fn home_dir() -> Option<PathBuf> {
     return env::var_os("HOME")
         .and_then(|h| if h.is_empty() { None } else { Some(h) })


### PR DESCRIPTION
Line 30 of `lib.rs` had a broken url. I replaced it with a new perma-link to the correct code.

By the way, I realized the new code has added some new platforms (redox, vxworks, espidf and horizon) to the fallback. I know nothing about these platforms, so I'm unsure if we should update  `dirs-sys-rs`'s code to also include them.