### PR TITLE
migrate winapi to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,9 @@ libc = "0.2"
 redox_users = { version = "0.4", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }
+windows = { version = "0.44.0", features = [
+    "Win32_UI_Shell",
+    "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_System_Com",
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,78 +132,81 @@ pub fn user_dirs(home_dir_path: &Path) -> HashMap<String, PathBuf> {
 pub use self::target_unix_not_mac::{user_dir, user_dirs};
 
 #[cfg(target_os = "windows")]
-extern crate winapi;
+extern crate windows;
 
 #[cfg(target_os = "windows")]
 mod target_windows {
 
+use std::ffi::c_void;
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
-use std::ptr;
 use std::slice;
 
-use super::winapi;
-use super::winapi::shared::winerror;
-use super::winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
+use super::windows::Win32;
+use super::windows::Win32::UI::Shell;
 
-pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
+pub fn known_folder(folder_id: windows::core::GUID) -> Option<PathBuf> {
     unsafe {
-        let mut path_ptr: winnt::PWSTR = ptr::null_mut();
-        let result = shlobj::SHGetKnownFolderPath(folder_id, 0, ptr::null_mut(), &mut path_ptr);
-        if result == winerror::S_OK {
-            let len = winbase::lstrlenW(path_ptr) as usize;
-            let path = slice::from_raw_parts(path_ptr, len);
+        let path_ptr = windows::core::PCWSTR::null();
+        let result = Shell::SHGetKnownFolderPath(
+            &folder_id,
+            Shell::KNOWN_FOLDER_FLAG(0),
+            Win32::Foundation::HANDLE::default(),
+        );
+        if result.is_ok() {
+            let len = windows::Win32::Globalization::lstrlenW(path_ptr) as usize;
+            let path = slice::from_raw_parts(path_ptr.0, len);
             let ostr: OsString = OsStringExt::from_wide(path);
-            combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+            windows::Win32::System::Com::CoTaskMemFree(Some(path_ptr.0 as *const c_void));
             Some(PathBuf::from(ostr))
         } else {
-            combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+            windows::Win32::System::Com::CoTaskMemFree(Some(path_ptr.0 as *const c_void));
             None
         }
     }
 }
 
 pub fn known_folder_profile() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Profile)
+    known_folder(Shell::FOLDERID_Profile)
 }
 
 pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_RoamingAppData)
+    known_folder(Shell::FOLDERID_RoamingAppData)
 }
 
 pub fn known_folder_local_app_data() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_LocalAppData)
+    known_folder(Shell::FOLDERID_RoamingAppData)
 }
 
 pub fn known_folder_music() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Music)
+    known_folder(Shell::FOLDERID_Music)
 }
 
 pub fn known_folder_desktop() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Desktop)
+    known_folder(Shell::FOLDERID_Desktop)
 }
 
 pub fn known_folder_documents() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Documents)
+    known_folder(Shell::FOLDERID_Documents)
 }
 
 pub fn known_folder_downloads() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Downloads)
+    known_folder(Shell::FOLDERID_Downloads)
 }
 
 pub fn known_folder_pictures() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Pictures)
+    known_folder(Shell::FOLDERID_Pictures)
 }
 
 pub fn known_folder_public() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Public)
+    known_folder(Shell::FOLDERID_Public)
 }
 pub fn known_folder_templates() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Templates)
+    known_folder(Shell::FOLDERID_Templates)
 }
 pub fn known_folder_videos() -> Option<PathBuf> {
-    known_folder(&knownfolders::FOLDERID_Videos)
+    known_folder(Shell::FOLDERID_Videos)
 }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
 }
 
 pub fn known_folder_local_app_data() -> Option<PathBuf> {
-    known_folder(Shell::FOLDERID_RoamingAppData)
+    known_folder(Shell::FOLDERID_LocalAppData)
 }
 
 pub fn known_folder_music() -> Option<PathBuf> {


### PR DESCRIPTION
This PR migrates winapi-rs to [windows-rs](https://github.com/microsoft/windows-rs). windows-rs is the bindings crate provided by Microsoft, and is actively maintained compared to winapi-rs.