### PR TITLE
Add a cargo feature to disable the `getpwuid_r` fallback.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository  = "https://github.com/dirs-dev/dirs-sys-rs"
 maintenance = { status = "as-is" }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_users = { version = "0.4", default-features = false }
@@ -21,3 +21,14 @@ windows-sys = { version = "0.48.0", features = [
     "Win32_Globalization",
     "Win32_System_Com",
 ] }
+
+[features]
+default = ["getpwuid"]
+
+# Default features, except follow the behavior of libxdg-basedir, which does
+# not fall back to `getpwuid_r`.
+default_xdg = []
+
+# Enable this to have dirs-sys call `getpwuid_r` as a fallback in case `HOME`
+# is unset or empty.
+getpwuid = ["libc"]


### PR DESCRIPTION
Currently dirs-sys falls back to calling `getpwuid_r` when the `HOME` environment variable is not set, on most Unix-like platforms.

This is undesirable for at least some users, because such behavior is not specified in the [XDG Base Directory Specification] and differs from the behavior of the widely used libxdg-basedir. And, calling `getpwuid_r` means depending on a part of libc which, on some platforms, calls `dlopen` and runs third-party code that uses filesystem and networking in-process, which can create problems for some sandboxing scenarios.

This PR puts `getpwuid_r` under control of a feature flag, enabled by default to maintain compatibility with existing users of the crate, but which can be disabled by users who don't desire the `getpwuid_r` behavior.

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html