### PR TITLE
Remove option-ext dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/dirs-dev/dirs-sys-rs"
 maintenance = { status = "as-is" }
 
-[dependencies]
-option-ext = "0.2.0"
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate option_ext;
-
 use std::ffi::OsString;
 use std::path::PathBuf;
 

--- a/src/xdg_user_dirs.rs
+++ b/src/xdg_user_dirs.rs
@@ -6,8 +6,6 @@ use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::str;
 
-use option_ext::OptionExt;
-
 /// Returns all XDG user directories obtained from $(XDG_CONFIG_HOME)/user-dirs.dirs.
 pub fn all(home_dir_path: &Path, user_dir_file_path: &Path) -> HashMap<String, PathBuf> {
     let bytes = read_all(user_dir_file_path).unwrap_or(Vec::new());
@@ -34,7 +32,7 @@ fn parse_user_dirs(home_dir: &Path, user_dir: Option<&str>, bytes: &[u8]) -> Has
         let key = if key.starts_with(b"XDG_") && key.ends_with(b"_DIR") {
             match str::from_utf8(&key[4..key.len()-4]) {
                 Ok(key) =>
-                    if user_dir.contains(&key) {
+                    if user_dir == Some(key) {
                         single_dir_found = true;
                         key
                     } else if user_dir.is_none() {


### PR DESCRIPTION
I found a way to replace the use of this dependency with a trivial compare.